### PR TITLE
Make math and 'almost' functions publicly available.

### DIFF
--- a/chai-stats.js
+++ b/chai-stats.js
@@ -105,6 +105,58 @@ exports.sdeviation = function (nums) {
   return Math.sqrt(davg);
 };
 
+function tolerance(precision){
+  if(precision == null) precision = 7;
+  return 0.5 * Math.pow(10, -precision);
+}
+
+/**
+ *
+ * # almostEqual
+ *
+ * Returns true if the two arguments are equal within the given precision.
+ *
+ * @param {Number} a
+ * @param {Number} b
+ * @param {Number} precision. Optional: defaults to 7.
+ * @return {Boolean} true if the two arguments are equal with precision decimal places.
+ *
+ */
+
+exports.almostEqual = function (a,b,precision){
+  return Math.abs(a - b) < tolerance(precision);
+};
+
+/**
+ *
+ * # deepAlmostEqual
+ *
+ * Returns true if all the objects are deeply equal, within the given precision.
+ *
+ * @param {Object} a
+ * @param {Object} b
+ * @param {Number} precision. Optional: defaults to 7.
+ * @return {Boolean} true if the two arguments are deeply equal with precision decimal places.
+ */
+
+exports.deepAlmostEqual = function(a,b,precision){
+  var tol = tolerance(precision);
+  function deepEql (act, exp) {
+    if (Object(act) === act){
+      for (var k in act) {
+        if (!(deepEql(act[k], exp[k]))) {
+          return false;
+        }
+      }
+      return true;
+    } else {
+      return Math.abs(act - exp) < tol;
+    }
+  }
+
+  return deepEql(a,b);
+};
+
 }); // module calc
 
 
@@ -139,10 +191,10 @@ module.exports = function (chai, _) {
   Assertion.overwriteMethod('equal', function(_super) {
     return function equal (exp, precision) {
       if (flag(this, 'almost')) {
-        var act = flag(this, 'object')
-        if (null == precision) precision = 7;
+        var act = flag(this, 'object');
+        if(precision == null) precision = 7;
         this.assert(
-            Math.abs(act - exp) < 0.5 * Math.pow(10, -precision)
+            calc.almostEqual(exp,act,precision)
           , "expected #{this} to equal #{exp} up to " + _.inspect(precision) + " decimal places"
           , "expected #{this} to not equal #{exp} up to " + _.inspect(precision) + " decimal places"
           , exp
@@ -177,25 +229,10 @@ module.exports = function (chai, _) {
   Assertion.overwriteMethod('eql', function (_super) {
     return function eql (exp, precision) {
       if (flag(this, 'almost')) {
-        if (null == precision) precision = 7;
-        var act = flag(this, 'object')
-          , tol = 0.5 * Math.pow(10, -precision);
-
-        function deepEql (act, exp) {
-          if (Object(act) === act){
-            for (var k in act) {
-              if (!(deepEql(act[k], exp[k]))) {
-                return false;
-              }
-            }
-            return true;
-          } else {
-            return Math.abs(act - exp) < tol;
-          }
-        };
-
+        var act = flag(this, 'object') ;
+        if(precision == null) precision = 7;
         this.assert(
-            deepEql(act, exp)
+            calc.deepAlmostEqual(act,exp,precision)
           , "expected #{this} to equal #{exp} up to " + _.inspect(precision) + ' decimal places'
           , "expected #{this} to not equal #{exp} up to " + _.inspect(precision) + ' decimal places'
           , exp
@@ -279,6 +316,11 @@ module.exports = function (chai, _) {
   Assertion.addProperty('deviation', deviation);
 };
 
+for(var i in calc){
+  if(calc.hasOwnProperty(i)){
+    module.exports[i] = calc[i];
+  }
+}
 }); // module stats
   return require('stats');
 });

--- a/lib/calc.js
+++ b/lib/calc.js
@@ -53,3 +53,55 @@ exports.sdeviation = function (nums) {
   var davg = exports.sum(devs) / (devs.length - 1);
   return Math.sqrt(davg);
 };
+
+function tolerance(precision){
+  if(precision == null) precision = 7;
+  return 0.5 * Math.pow(10, -precision);
+}
+
+/**
+ *
+ * # almostEqual
+ *
+ * Returns true if the two arguments are equal within the given precision.
+ *
+ * @param {Number} a
+ * @param {Number} b
+ * @param {Number} precision. Optional: defaults to 7.
+ * @return {Boolean} true if the two arguments are equal with precision decimal places.
+ *
+ */
+
+exports.almostEqual = function (a,b,precision){
+  return Math.abs(a - b) < tolerance(precision);
+};
+
+/**
+ *
+ * # deepAlmostEqual
+ *
+ * Returns true if all the objects are deeply equal, within the given precision.
+ *
+ * @param {Object} a
+ * @param {Object} b
+ * @param {Number} precision. Optional: defaults to 7.
+ * @return {Boolean} true if the two arguments are deeply equal with precision decimal places.
+ */
+
+exports.deepAlmostEqual = function(a,b,precision){
+  var tol = tolerance(precision);
+  function deepEql (act, exp) {
+    if (Object(act) === act){
+      for (var k in act) {
+        if (!(deepEql(act[k], exp[k]))) {
+          return false;
+        }
+      }
+      return true;
+    } else {
+      return Math.abs(act - exp) < tol;
+    }
+  }
+
+  return deepEql(a,b);
+};

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -28,10 +28,10 @@ module.exports = function (chai, _) {
   Assertion.overwriteMethod('equal', function(_super) {
     return function equal (exp, precision) {
       if (flag(this, 'almost')) {
-        var act = flag(this, 'object')
-        if (null == precision) precision = 7;
+        var act = flag(this, 'object');
+        if(precision == null) precision = 7;
         this.assert(
-            Math.abs(act - exp) < 0.5 * Math.pow(10, -precision)
+            calc.almostEqual(exp,act,precision)
           , "expected #{this} to equal #{exp} up to " + _.inspect(precision) + " decimal places"
           , "expected #{this} to not equal #{exp} up to " + _.inspect(precision) + " decimal places"
           , exp
@@ -66,25 +66,10 @@ module.exports = function (chai, _) {
   Assertion.overwriteMethod('eql', function (_super) {
     return function eql (exp, precision) {
       if (flag(this, 'almost')) {
-        if (null == precision) precision = 7;
-        var act = flag(this, 'object')
-          , tol = 0.5 * Math.pow(10, -precision);
-
-        function deepEql (act, exp) {
-          if (Object(act) === act){
-            for (var k in act) {
-              if (!(deepEql(act[k], exp[k]))) {
-                return false;
-              }
-            }
-            return true;
-          } else {
-            return Math.abs(act - exp) < tol;
-          }
-        };
-
+        var act = flag(this, 'object') ;
+        if(precision == null) precision = 7;
         this.assert(
-            deepEql(act, exp)
+            calc.deepAlmostEqual(act,exp,precision)
           , "expected #{this} to equal #{exp} up to " + _.inspect(precision) + ' decimal places'
           , "expected #{this} to not equal #{exp} up to " + _.inspect(precision) + ' decimal places'
           , exp
@@ -167,3 +152,9 @@ module.exports = function (chai, _) {
   Assertion.addProperty('stdev', deviation);
   Assertion.addProperty('deviation', deviation);
 };
+
+for(var i in calc){
+  if(calc.hasOwnProperty(i)){
+    module.exports[i] = calc[i];
+  }
+}

--- a/test/stats.js
+++ b/test/stats.js
@@ -1,17 +1,23 @@
+var tmp;
 if (!chai) {
   var chai = require('chai')
     , stats = require('..');
   chai.use(stats);
+  tmp = stats;
+}
+else {
+  tmp = chai_stats;
 }
 
 var should = chai.should()
   , assert = chai.assert
-  , expect = chai.expect;
+  , expect = chai.expect
+  , chai_stats = tmp;
 
 describe('Chai Stats', function () {
 
   describe('Math Basics', function () {
-    var nums = [ 1, 3, 5, 7, 9, ];
+    var nums = [ 1, 3, 5, 7, 9 ];
 
     it('should be able to get the sum of a set of numbers', function () {
       nums.should.have.sum.equal(25);
@@ -64,5 +70,30 @@ describe('Chai Stats', function () {
       expect(3.1415).to.not.almost.equal(3); // precision undefined => 7 decimal places
       expect(5.8).to.almost.equal(6, 0); // precision 0 => rounding
     });
+  });
+
+  describe('math functions are publicly available',function(){
+
+    var nums = [ 1, 3, 5, 7, 9 ];
+
+    it('almostEqual',function(){
+      expect(chai_stats.almostEqual(3.1415,3,0)).to.be.true;
+      expect(chai_stats.almostEqual(3.1415,3.1416,3)).to.be.true;
+      expect(chai_stats.almostEqual(3.1415,3.1416,4)).to.be.false;
+    });
+    it('deepAlmostEqual',function(){
+      expect(chai_stats.deepAlmostEqual({ pi: 3.1416 },{ pi: 3 },0)).to.be.true;
+      expect(chai_stats.deepAlmostEqual({ pi: 3.1416 },{ pi: 3.14159 },4)).to.be.true;
+      expect(chai_stats.deepAlmostEqual({ pi: 3.1416 },{ pi: 3.14159 },5)).to.be.false;
+    });
+    it('mean',function(){
+      expect(chai_stats.mean(nums)).to.equal(5);
+    });
+    it('sum',function(){
+      expect(chai_stats.sum(nums)).to.equal(25);
+    });
+    it('sdeviation',function(){
+      expect(chai_stats.sdeviation(nums)).to.equal(3.1622776601683795);
+    })
   });
 });


### PR DESCRIPTION
Exposes underlying assertion logic as functions that return numbers (`mean`,`sum`,`sdeviation`) or booleans (`almostEqual`, `deepAlmostEqual`). Primary use would be other chai plugins that are overriding some behavior.

Usage:

``` javascript
require('chai-stats').almostEqual(3.14159,3,0);
// evaluates to true  
```
