### PR TITLE
Allow deepAlmostEqual to operate on arrays.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Chai spies are available on npm.
 
 #### Browser
 
-Include `chai-stats.js` after including `chai.js`. 
+Include `chai-stats.js` after including `chai.js`.
 
 ```xml
 <script src="chai-stats.js"></script>
@@ -32,7 +32,7 @@ var chai = require('chai')
 chai.use(chaiStats);
 
 var should = chai.should()
-  , expect = chai.expect; 
+  , expect = chai.expect;
 ```
 
 ## API Reference
@@ -57,6 +57,12 @@ expect({ pi: 3.1416 }).to.almost.eql({ pi: 3.14159 }, 3);
 assert.deepAlmostEqual({ pi: 3.1416 }, { pi: 3.14159 }, 3);
 ```
 
+Also works for arrays and nested arrays whose leaves are all numbers.
+
+```javascript
+expect([[4.5678, 5.5678]]).to.almost.eql([[4.56789, 5.56789]], 3);
+assert.deepAlmostEqual([[4.5678, 5.5678]], [[4.56789, 5.56789]], 3);
+```
 
 #### .sum
 
@@ -92,7 +98,7 @@ compared using chai's core assertions.
 expect([ 1, 2, 3, 4 ]).to.have.deviation.almost.equal(1.290, 2);
 ```
 
-## Tests 
+## Tests
 
 Tests are written using [mocha](http://github.com/visionmedia/mocha) in the BDD interface.
 Node tests can be executed using `make test`. Browser tests can be seen by opening `test/browser/index.html`.

--- a/lib/calc.js
+++ b/lib/calc.js
@@ -91,7 +91,15 @@ exports.almostEqual = function (a,b,precision){
 exports.deepAlmostEqual = function(a,b,precision){
   var tol = tolerance(precision);
   function deepEql (act, exp) {
-    if (Object(act) === act){
+    if (Object.prototype.toString.call(act) === '[object Array]') {
+      if (act.length !== exp.length) return false;
+      for (var i=0; i<act.length; i++) {
+        if (!(deepEql(act[i], exp[i]))) {
+          return false;
+        }
+      }
+      return true;
+    } else if (Object(act) === act){
       for (var k in act) {
         if (!(deepEql(act[k], exp[k]))) {
           return false;

--- a/test/stats.js
+++ b/test/stats.js
@@ -64,16 +64,16 @@ describe('Chai Stats', function () {
     });
 
     it('should work: .almost.eql // deepAlmostEqual for arrays', function() {
-      ([4.567, 5.567, 6.567]).should.almost.eql([4.5678, 5.5678, 6.5678], 3);
-      assert.deepAlmostEqual([4.567, 5.567, 6.567], [4.5678, 5.5678, 6.5678], 3);
+      ([4.5678, 5.5678, 6.5678]).should.almost.eql([4.56789, 5.56789, 6.56789], 3);
+      assert.deepAlmostEqual([4.5678, 5.5678, 6.5678], [4.56789, 5.56789, 6.56789], 3);
 
       (function () {
-        assert.deepAlmostEqual([4.567, 5.567, 6.567], [4.5678, 5.5678, 6.5678], 6);
-      }).should.throw(chai.AssertionError, "expected [ 4.567, 5.567, 6.567 ] to equal [ 4.5678, 5.5678, 6.5678 ] up to 6 decimal places");
+        assert.deepAlmostEqual([4.5678, 5.5678, 6.5678], [4.56789, 5.56789, 6.56789], 6);
+      }).should.throw(chai.AssertionError, "expected [ 4.5678, 5.5678, 6.5678 ] to equal [ 4.56789, 5.56789, 6.56789 ] up to 6 decimal places");
 
       (function () {
-        assert.deepAlmostEqual([4.567, 5.567, 6.567], [4.5678, 5.5678, 6.5678]);
-      }).should.throw(chai.AssertionError, "expected [ 4.567, 5.567, 6.567 ] to equal [ 4.5678, 5.5678, 6.5678 ] up to 7 decimal places");
+        assert.deepAlmostEqual([4.5678, 5.5678, 6.5678], [4.56789, 5.56789, 6.56789]);
+      }).should.throw(chai.AssertionError, "expected [ 4.5678, 5.5678, 6.5678 ] to equal [ 4.56789, 5.56789, 6.56789 ] up to 7 decimal places");
     });
 
     it('should round to nearest number if explicitely given 0 precision', function() {

--- a/test/stats.js
+++ b/test/stats.js
@@ -75,6 +75,10 @@ describe('Chai Stats', function () {
       (function () {
         assert.deepAlmostEqual([4.5678, 5.5678, 6.5678], [4.56789, 5.56789, 6.56789]);
       }).should.throw(chai.AssertionError, "expected [ 4.5678, 5.5678, 6.5678 ] to equal [ 4.56789, 5.56789, 6.56789 ] up to 7 decimal places");
+
+      (function () {
+        assert.deepAlmostEqual([[4.5678, 5.5678, 6.5678]], [[4.56789, 5.56789, 6.56789], [1, 2, 3]], 3);
+      }).should.throw(chai.AssertionError, "expected [ [ 4.5678, 5.5678, 6.5678 ] ] to equal [ Array(2) ] up to 3 decimal places");
     });
 
     it('should round to nearest number if explicitely given 0 precision', function() {

--- a/test/stats.js
+++ b/test/stats.js
@@ -66,6 +66,7 @@ describe('Chai Stats', function () {
     it('should work: .almost.eql // deepAlmostEqual for arrays', function() {
       ([4.5678, 5.5678, 6.5678]).should.almost.eql([4.56789, 5.56789, 6.56789], 3);
       assert.deepAlmostEqual([4.5678, 5.5678, 6.5678], [4.56789, 5.56789, 6.56789], 3);
+      assert.deepAlmostEqual([[4.5678, 5.5678, 6.5678]], [[4.56789, 5.56789, 6.56789]], 3);
 
       (function () {
         assert.deepAlmostEqual([4.5678, 5.5678, 6.5678], [4.56789, 5.56789, 6.56789], 6);

--- a/test/stats.js
+++ b/test/stats.js
@@ -62,7 +62,20 @@ describe('Chai Stats', function () {
       }).should.throw(chai.AssertionError, "expected { pi: 3.1416 } to equal { pi: 3.14159 } up to 7 decimal places");
 
     });
-    
+
+    it('should work: .almost.eql // deepAlmostEqual for arrays', function() {
+      ([4.567, 5.567, 6.567]).should.almost.eql([4.5678, 5.5678, 6.5678], 3);
+      assert.deepAlmostEqual([4.567, 5.567, 6.567], [4.5678, 5.5678, 6.5678], 3);
+
+      (function () {
+        assert.deepAlmostEqual([4.567, 5.567, 6.567], [4.5678, 5.5678, 6.5678], 6);
+      }).should.throw(chai.AssertionError, "expected [ 4.567, 5.567, 6.567 ] to equal [ 4.5678, 5.5678, 6.5678 ] up to 6 decimal places");
+
+      (function () {
+        assert.deepAlmostEqual([4.567, 5.567, 6.567], [4.5678, 5.5678, 6.5678]);
+      }).should.throw(chai.AssertionError, "expected [ 4.567, 5.567, 6.567 ] to equal [ 4.5678, 5.5678, 6.5678 ] up to 7 decimal places");
+    });
+
     it('should round to nearest number if explicitely given 0 precision', function() {
       ({ pi: 3.1416 }).should.almost.eql({ pi: 3 }, 0);
       assert.deepAlmostEqual({pi: 3.1416}, {pi: 3}, 0);


### PR DESCRIPTION
Proposed enhancement to allow deepAlmostEqual to work with arrays and nested arrays whose leaves are all numbers.
